### PR TITLE
chore(ci): build image once; skip frontend rebuild for non-frontend PRs

### DIFF
--- a/.github/workflows/all_in_one_k8s.yml
+++ b/.github/workflows/all_in_one_k8s.yml
@@ -69,6 +69,10 @@ jobs:
     if: "${{ inputs.do_build == true }}"
     outputs:
       TAGS: ${{ steps.meta.outputs.tags }}
+      # SHA_TAG is the immutable per-commit tag used by deploy-k8s for
+      # --set image=. Callers that previously consumed TAGS for a single
+      # tag can switch to SHA_TAG; TAGS still carries both tags for cleanup.
+      SHA_TAG: ${{ steps.sha-tag.outputs.tag }}
     needs: setup
     steps:
       - name: Checkout
@@ -86,23 +90,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Get Docker metadata - SHA tag
+      - name: Get Docker metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/apifornia/${{ needs.setup.outputs.APP_NAME }}
+          # Publish both the immutable SHA tag (consumed by pr-stand.yml as
+          # PR_REPO_IMAGE) and the mutable ENV tag (e.g. "dev") in a single
+          # build — previously two independent docker/build-push-action runs
+          # doubled the build wall-clock time for every service-affecting PR.
           tags: |
             type=raw,value=${{ github.sha }}
-
-      - name: Get Docker metadata - ENV tag
-        id: meta2
-        uses: docker/metadata-action@v4
-        with:
-          images: ghcr.io/apifornia/${{ needs.setup.outputs.APP_NAME }}
-          tags: |
             type=raw,value=${{ needs.setup.outputs.EXTRA_TAG }}
 
-      - name: Build and push - SHA tag
+      - name: Build and push
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -112,15 +113,11 @@ jobs:
           labels: |
             project=apifornia
 
-      - name: Build and push - ENV tag
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: ${{ inputs.docker_file }}
-          push: ${{ inputs.do_build_push }}
-          tags: ${{ steps.meta2.outputs.tags }}
-          labels: |
-            project=apifornia
+      - name: Extract SHA tag
+        id: sha-tag
+        run: |
+          SHA_TAG=$(echo "${{ steps.meta.outputs.tags }}" | grep "${{ github.sha }}" | head -1)
+          echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
   # DEPLOY
   deploy-k8s:
     needs: [setup,build]
@@ -160,7 +157,7 @@ jobs:
           --install \
           --atomic \
           --namespace "${{ needs.setup.outputs.NAMESPACE }}" \
-          --set image="${{ needs.build.outputs.TAGS }}" \
+          --set image="${{ needs.build.outputs.SHA_TAG }}" \
           --set git_commit="${GITHUB_SHA}"
 
   # CLEANUP

--- a/.github/workflows/pr-stand.yml
+++ b/.github/workflows/pr-stand.yml
@@ -83,70 +83,87 @@ jobs:
   # =========================
   # FRONTEND build and deploy
   # =========================
+  # For flow-editor-vue3 PRs the frontend is rebuilt from the PR branch so
+  # changes are exercised in the stand. For every other caller the published
+  # ghcr.io/apifornia/flow-editor-vue3:develop image is pulled, retagged
+  # with the PR namespace tag, and deployed — skipping the ~1-minute build.
   frontend-up:
     needs: [setup,infra]
     runs-on: apifornia-builder
-    #if: "${{ needs.setup.outputs.CALLER_REPO_NAME != 'flow-editor-vue3' }}"
-    outputs:
-      IMAGE_ID: ${{ steps.front-build.outputs.imageid }}
     steps:
-      - id: setup
-        name: Setup
-        run: >
-          if [ ${{ needs.setup.outputs.CALLER_REPO_NAME }} == 'flow-editor-vue3' ]; then
-            echo "BRANCH=${GITHUB_HEAD_REF}"
-            echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT
-          else
-            echo "BRANCH=develop"
-            echo "BRANCH=develop" >> $GITHUB_OUTPUT
-          fi
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.gh_token }}
-      - name: Get Docker metadata
+
+      # ---- non-frontend callers: retag published develop image ----
+      - name: Pull and retag develop image (non-frontend PRs)
+        if: needs.setup.outputs.CALLER_REPO_NAME != 'flow-editor-vue3'
+        run: |
+          docker pull ghcr.io/apifornia/flow-editor-vue3:develop
+          docker tag  ghcr.io/apifornia/flow-editor-vue3:develop \
+                      ghcr.io/apifornia/flow-editor-vue3:${{ needs.setup.outputs.PR_ID }}
+          docker push ghcr.io/apifornia/flow-editor-vue3:${{ needs.setup.outputs.PR_ID }}
+
+      # ---- frontend callers: full build from PR branch ----
+      - name: Get Docker metadata (frontend PR)
         id: meta
+        if: needs.setup.outputs.CALLER_REPO_NAME == 'flow-editor-vue3'
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/apifornia/flow-editor-vue3
           tags: |
             type=raw,value=${{ needs.setup.outputs.PR_ID }}
-      - name: Clone apifornia/flow-editor-vue3
+      - name: Clone apifornia/flow-editor-vue3 (frontend PR)
+        if: needs.setup.outputs.CALLER_REPO_NAME == 'flow-editor-vue3'
         uses: actions/checkout@v4
         with:
           repository: apifornia/flow-editor-vue3
-          ref: ${{ steps.setup.outputs.BRANCH }}
-          #ref: pr
+          ref: ${{ github.head_ref }}
           path: .github/flow-editor-vue3_${{ needs.setup.outputs.PR_ID }}
           token: ${{ secrets.gh_token }}
-      - name: Get env file
+      - name: Get env file (frontend PR)
+        if: needs.setup.outputs.CALLER_REPO_NAME == 'flow-editor-vue3'
         run: |
           echo Get env vars:
           echo  "${{ secrets.gh_token }}" | gh auth login --with-token
           gh variable get PR --repo apifornia/flow-editor-vue3 > .github/flow-editor-vue3_${{ needs.setup.outputs.PR_ID }}/.env
-          
-          # echo Setting unique id
+
           sed -i 's/<pr-id>/${{ needs.setup.outputs.PR_ID }}/' .github/flow-editor-vue3_${{ needs.setup.outputs.PR_ID }}/.env
           sed -i 's/<pr-id>/${{ needs.setup.outputs.PR_ID }}/' .github/flow-editor-vue3_${{ needs.setup.outputs.PR_ID }}/deploy/chart/values-pr.yml
-      - id: front-build-push
-        name: Build
+      - name: Build and push (frontend PR)
+        if: needs.setup.outputs.CALLER_REPO_NAME == 'flow-editor-vue3'
         uses: docker/build-push-action@v4
         with:
           context: .github/flow-editor-vue3_${{ needs.setup.outputs.PR_ID }}
           file: .github/flow-editor-vue3_${{ needs.setup.outputs.PR_ID }}/deploy/docker/images/dev/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          #secret-files: flow-editor-vue3_${{ needs.setup.outputs.PR_ID }}/.env
-      - name: Update and run ${{ matrix.app }}
+
+      # ---- deploy (both paths use the same PR_ID tag) ----
+      - name: Clone apifornia/flow-editor-vue3 chart
+        uses: actions/checkout@v4
+        with:
+          repository: apifornia/flow-editor-vue3
+          ref: develop
+          path: .github/flow-editor-vue3_chart_${{ needs.setup.outputs.PR_ID }}
+          token: ${{ secrets.gh_token }}
+      - name: Get env file for deploy
+        run: |
+          echo  "${{ secrets.gh_token }}" | gh auth login --with-token
+          gh variable get PR --repo apifornia/flow-editor-vue3 > .github/flow-editor-vue3_chart_${{ needs.setup.outputs.PR_ID }}/.env
+          sed -i 's/<pr-id>/${{ needs.setup.outputs.PR_ID }}/' .github/flow-editor-vue3_chart_${{ needs.setup.outputs.PR_ID }}/.env
+          sed -i 's/<pr-id>/${{ needs.setup.outputs.PR_ID }}/' .github/flow-editor-vue3_chart_${{ needs.setup.outputs.PR_ID }}/deploy/chart/values-pr.yml
+      - name: Deploy flow-editor-vue3
         run: |
           export HELM_KUBECONTEXT=apifornia-dev
-          cd .github/flow-editor-vue3_${{ needs.setup.outputs.PR_ID }}
+          cd .github/flow-editor-vue3_chart_${{ needs.setup.outputs.PR_ID }}
           helm install "flow-editor-vue3" ./deploy/chart \
           -f ./deploy/chart/values-pr.yml \
           --namespace "${{ needs.setup.outputs.PR_ID }}" \
-          --set image="${{ steps.meta.outputs.tags }}"
+          --set image="ghcr.io/apifornia/flow-editor-vue3:${{ needs.setup.outputs.PR_ID }}"
 
   # ===============
   # APPS deployment

--- a/.github/workflows/pr-stand.yml
+++ b/.github/workflows/pr-stand.yml
@@ -143,7 +143,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
 
       # ---- deploy (both paths use the same PR_ID tag) ----
-      - name: Clone apifornia/flow-editor-vue3 chart
+      # For frontend PRs the repo was already cloned from head_ref above, so
+      # we reuse that clone. For non-frontend PRs we clone the chart from develop.
+      - name: Clone apifornia/flow-editor-vue3 chart (non-frontend PRs)
+        if: needs.setup.outputs.CALLER_REPO_NAME != 'flow-editor-vue3'
         uses: actions/checkout@v4
         with:
           repository: apifornia/flow-editor-vue3
@@ -153,13 +156,21 @@ jobs:
       - name: Get env file for deploy
         run: |
           echo  "${{ secrets.gh_token }}" | gh auth login --with-token
-          gh variable get PR --repo apifornia/flow-editor-vue3 > .github/flow-editor-vue3_chart_${{ needs.setup.outputs.PR_ID }}/.env
-          sed -i 's/<pr-id>/${{ needs.setup.outputs.PR_ID }}/' .github/flow-editor-vue3_chart_${{ needs.setup.outputs.PR_ID }}/.env
-          sed -i 's/<pr-id>/${{ needs.setup.outputs.PR_ID }}/' .github/flow-editor-vue3_chart_${{ needs.setup.outputs.PR_ID }}/deploy/chart/values-pr.yml
+          CHART_PATH=.github/flow-editor-vue3_chart_${{ needs.setup.outputs.PR_ID }}
+          if [ "${{ needs.setup.outputs.CALLER_REPO_NAME }}" == "flow-editor-vue3" ]; then
+            CHART_PATH=.github/flow-editor-vue3_${{ needs.setup.outputs.PR_ID }}
+          fi
+          gh variable get PR --repo apifornia/flow-editor-vue3 > ${CHART_PATH}/.env
+          sed -i 's/<pr-id>/${{ needs.setup.outputs.PR_ID }}/' ${CHART_PATH}/.env
+          sed -i 's/<pr-id>/${{ needs.setup.outputs.PR_ID }}/' ${CHART_PATH}/deploy/chart/values-pr.yml
       - name: Deploy flow-editor-vue3
         run: |
           export HELM_KUBECONTEXT=apifornia-dev
-          cd .github/flow-editor-vue3_chart_${{ needs.setup.outputs.PR_ID }}
+          CHART_PATH=.github/flow-editor-vue3_chart_${{ needs.setup.outputs.PR_ID }}
+          if [ "${{ needs.setup.outputs.CALLER_REPO_NAME }}" == "flow-editor-vue3" ]; then
+            CHART_PATH=.github/flow-editor-vue3_${{ needs.setup.outputs.PR_ID }}
+          fi
+          cd ${CHART_PATH}
           helm install "flow-editor-vue3" ./deploy/chart \
           -f ./deploy/chart/values-pr.yml \
           --namespace "${{ needs.setup.outputs.PR_ID }}" \


### PR DESCRIPTION
## Зачем это нужно

Сейчас на каждый PR в wand (и в любых сервисных репо, использующих эти reusable workflows) CI делает две лишние тяжёлые операции:

1. **Дважды собирает один и тот же Docker-образ** — `all_in_one_k8s.yml` запускает `docker/build-push-action` отдельно под SHA-тег и отдельно под ENV-тег (`dev`), хотя содержимое образа абсолютно одинаковое. Это ~1 минута впустую на каждый сервисный PR.
2. **Каждый PR пересобирает фронт `flow-editor-vue3` с нуля** — `pr-stand.yml` клонирует репо фронта и гоняет полный webpack build, даже если PR вообще не трогает фронт (например, бэкенд-PR в wand). Ещё ~1 минута впустую.

В сумме на каждом сервисном не-фронтовом PR теряется ~2 минуты, плюс CI-минуты ранера и cache pressure. На активном репо это превращается в десятки лишних минут в день и ощутимо замедляет цикл «push → стенд готов».

Идея PR — починить ровно эти два места: собирать образ один раз с двумя тегами, и для не-фронтовых PR подтягивать готовый `flow-editor-vue3:develop` через pull+retag вместо повторной сборки. Логика для самого `flow-editor-vue3` остаётся прежней (полная сборка из PR-ветки), чтобы фронтовые изменения по-прежнему проверялись.

## Что меняется

- **`all_in_one_k8s.yml`**: объединяем два независимых `docker/build-push-action` шага в одну сборку, которая пушит сразу оба тега — SHA-тег и ENV-тег (например `dev`). Добавлен output `SHA_TAG`, чтобы `deploy-k8s` получал однозначную ссылку на образ вместо многострочного `TAGS`.
- **`pr-stand.yml`**: для всех caller-репо, кроме `flow-editor-vue3`, образ фронта не пересобирается — мы просто pull'им и ретегаем уже опубликованный `ghcr.io/apifornia/flow-editor-vue3:develop`. PR из самого `flow-editor-vue3` по-прежнему собираются из PR-ветки. Обе ветки сходятся к одному и тому же `PR_ID` тегу перед общим шагом деплоя в Helm.

## Исправление регрессии (chart clone)

После рефактора шаг «Clone apifornia/flow-editor-vue3 chart» использовал `ref: develop` безусловно — то есть даже для PR из самого `flow-editor-vue3` деплоился chart с `develop`, а не с PR-ветки. Изменения в `deploy/chart/` в таких PR не проверялись на стенде.

Исправление: шаг клонирования chart выполняется только для не-фронтовых PR (`if: CALLER_REPO_NAME != 'flow-editor-vue3'`). Для фронтовых PR репо уже склонировано из `head_ref` на шаге сборки — шаги «Get env file» и «Deploy» теперь переключаются на этот путь.

## Изменения контракта callers

Ломающих изменений для существующих callers нет:

- Output `TAGS` у джобы `build` остался и теперь содержит оба тега (нужно для cleanup). Если кто-то полагался на `TAGS` как на одиночный тег — переключитесь на новый output `SHA_TAG`, потому что `TAGS` теперь многострочный.
- Новых обязательных inputs нет ни у одного workflow.
- У `pr-stand.yml` интерфейс inputs не меняется; логика skip-сборки фронта и выбор пути chart спрятаны внутри.

## Ожидаемая экономия времени

По данным запусков из issue:

| Что сэкономили | ~Wall-clock |
|---|---|
| `build / build` (повторная сборка Docker) | ~1 мин |
| `pr / frontend-up` clone + webpack build (для не-фронтовых PR) | ~1 мин |
| **Итого на сервисный не-фронтовый PR** | **~2 мин** |

Было: \`6m08s\`–\`8m47s\` суммарно. Ожидаем: \`4m\`–\`6m\` суммарно.

## План проверки

- [ ] Запустить сервисный PR в wand: убедиться, что \`build / build\` отрабатывает один раз, \`pr / frontend-up\` идёт быстрее (через pull+retag), watcher E2E проходит.
- [ ] Запустить PR в \`flow-editor-vue3\`: убедиться, что фронт всё так же собирается из PR-ветки, и chart деплоится тоже с PR-ветки (не с develop).
- [ ] Проверить, что после \`all_in_one_k8s.yml\` build'а опубликованы оба тега: \`ghcr.io/apifornia/<app>:<sha>\` и \`ghcr.io/apifornia/<app>:dev\`.

Refs apifornia/wand#1197