### PR TITLE
Update CI workflow to use uv for test execution

### DIFF
--- a/.github/workflows/dashboard_ci.yml
+++ b/.github/workflows/dashboard_ci.yml
@@ -12,11 +12,10 @@ jobs:
           python-version: "3.12"
       - name: Run tests
         run: |
-          pip install pytest
           pip install uv
-          uv sync
+          uv sync --group api --group interface --group dev
           # with verbose output
-          pytest -m unit -v
+          uv run pytest -m unit -v
           # with coverage report
-          pytest -m unit --cov=dashboard --cov-report=term-missing
+          uv run pytest -m unit --cov=dashboard --cov-report=term-missing
 


### PR DESCRIPTION
Fixed test workflow configuration.

Previously, dependencies were installed into the `uv` virtual environment, but tests were executed using the system Python interpreter. Because of that, some packages were not found during test execution.

Also added installation of additional dependency groups required for tests: `api` for API test dependencies, `interface` for web interface logic test dependencies, `dev` for `pytest` and related testing utilities